### PR TITLE
Bajo la cantidad de obstaculo inicial a 10

### DIFF
--- a/snake.c
+++ b/snake.c
@@ -29,6 +29,8 @@
 #include "conio.h"
 #include "snake.h"
 
+#define CANTIDAD_OBSTACULOS_INICIALES 10
+
 /* Default 0.2 sec between snake movement. */
 unsigned int usec_delay = DEFAULT_DELAY;
 
@@ -128,7 +130,7 @@ void setup_level (screen_t *screen, snake_t *snake, int level)
    if (1 == level)
    {
       screen->score     = -1500;
-      screen->obstacles = 10;
+      screen->obstacles = CANTIDAD_OBSTACULOS_INICIALES;
       screen->level     = 1;
       snake->speed      = 14;
       snake->dir        = RIGHT;

--- a/snake.c
+++ b/snake.c
@@ -128,7 +128,7 @@ void setup_level (screen_t *screen, snake_t *snake, int level)
    if (1 == level)
    {
       screen->score     = -1500;
-      screen->obstacles = 100;
+      screen->obstacles = 10;
       screen->level     = 1;
       snake->speed      = 14;
       snake->dir        = RIGHT;


### PR DESCRIPTION
Antes en el primer nivel arrancaba con 10 obstaculos, lo cual lo hacia muy complejo. Lo cambie por 5 y que luego en cada nivel se agregen mas.